### PR TITLE
Do not use Git tags or commit hashes in the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,7 @@ PDBDUMP_OBJECTS = $(COMMON_OBJECTS) $(patsubst %.cpp, %.o, $(wildcard src/pdbdum
 
 HEADERS = $(wildcard src/*/*.h) src/version.h
 
-VERSION_DEPS=VERSION .git/HEAD $(wildcard .git/refs/heads/*)
-
-src/version.h: src/version.h.in $(VERSION_DEPS)
+src/version.h: src/version.h.in VERSION scripts/version.py
 	./scripts/version.py $< $@
 
 src/%.o: src/%.cpp $(HEADERS)

--- a/src/ducible/main.cpp
+++ b/src/ducible/main.cpp
@@ -236,7 +236,7 @@ int ducible(int argc, CharT** argv) {
         std::cout << help;
         return 0;
     } catch (const CommandLineVersion&) {
-        std::cout << "ducible version " << DUCIBLE_VERSION << std::endl;
+        std::cout << DUCIBLE_VERSION << std::endl;
         return 0;
     }
 

--- a/src/ducible/main.cpp
+++ b/src/ducible/main.cpp
@@ -236,7 +236,7 @@ int ducible(int argc, CharT** argv) {
         std::cout << help;
         return 0;
     } catch (const CommandLineVersion&) {
-        std::cout << "ducible version " << DUCIBLE_PRETTY_VERSION << std::endl;
+        std::cout << "ducible version " << DUCIBLE_VERSION << std::endl;
         return 0;
     }
 

--- a/src/pdbdump/main.cpp
+++ b/src/pdbdump/main.cpp
@@ -211,7 +211,7 @@ int pdbdump(int argc, CharT** argv) {
         std::cout << help;
         return 0;
     } catch (const CommandLineVersion&) {
-        std::cout << "ducible version " << DUCIBLE_VERSION << std::endl;
+        std::cout << DUCIBLE_VERSION << std::endl;
         return 0;
     }
 

--- a/src/pdbdump/main.cpp
+++ b/src/pdbdump/main.cpp
@@ -211,7 +211,7 @@ int pdbdump(int argc, CharT** argv) {
         std::cout << help;
         return 0;
     } catch (const CommandLineVersion&) {
-        std::cout << "ducible version " << DUCIBLE_PRETTY_VERSION << std::endl;
+        std::cout << "ducible version " << DUCIBLE_VERSION << std::endl;
         return 0;
     }
 

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -44,23 +44,7 @@
 #define DUCIBLE_PATCH ${PATCH}
 #define DUCIBLE_BUILD 0 // Unused
 
-// The output of `git describe --always --dirty`. Note that this does not
-// include the major, minor, and patch versions.
-#define DUCIBLE_GIT_VERSION "${GIT_VERSION}"
-
-// A short version of the commit hash. This will be >=7 characters long. As many
-// characters as are needed to make the commit hash unique will be included.
-// This is the output of `git describe --always`.
-#define DUCIBLE_GIT_COMMIT_SHORT "${GIT_COMMIT_SHORT}"
-
-// The current full length commit hash. This is the output of `git rev-parse
-// HEAD`.
-#define DUCIBLE_GIT_COMMIT_LONG "${GIT_COMMIT_LONG}"
-
-#define DUCIBLE_VERSION "${MAJOR}.${MINOR}.${PATCH}-${GIT_VERSION}"
-
-// A pretty version in the form of "v1.0.0-226f798-dirty"
-#define DUCIBLE_PRETTY_VERSION "v${MAJOR}.${MINOR}.${PATCH}-${GIT_VERSION}"
+#define DUCIBLE_VERSION "${FULL_VERSION}"
 
 //
 // Miscellaneous information.
@@ -69,5 +53,5 @@
 #define DUCIBLE_INTERNAL_NAME     "Ducible"
 #define DUCIBLE_PRODUCT_NAME      "Ducible"
 #define DUCIBLE_DESCRIPTION       "Reproducible builds for Windows."
-#define DUCIBLE_COPYRIGHT         "Copyright (c) Jason White 2016"
+#define DUCIBLE_COPYRIGHT         "Copyright (c) Jason White 2018"
 #define DUCIBLE_ORIGINAL_FILENAME "ducible.exe"


### PR DESCRIPTION
This prevents building the source from zip files and is generally bad practice.

Fixes #17.